### PR TITLE
Release 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## Changelog
+
+## v3.0.0
 - [Breaking change] Add vanilla implementation - This change affects MobX implementations since we 
   have changed FormX<T> to be the vanilla implementation and applied the MobX implementation logic 
   in a new mixin FormXMobX<T>. Previous implementations of this should replace the FormX<T> usage 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_formx
 description: Flutter FormX provides an easy way of dealing with forms and their states without creating a lot of boilerplate code.
-version: 2.1.0
+version: 3.0.0
 homepage: https://github.com/revelojobs/flutter_formx
 repository: https://github.com/revelojobs/flutter_formx
 issue_tracker: https://github.com/revelojobs/flutter_formx/issues


### PR DESCRIPTION
- [Breaking change] Add vanilla implementation - This change affects MobX implementations since we 
  have changed FormX<T> to be the vanilla implementation and applied the MobX implementation logic 
  in a new mixin FormXMobX<T>. Previous implementations of this should replace the FormX<T> usage 
  with FormXMobX<T> to have the same behavior as in previous versions
- Add Bloc implementation
- Restructure the library's folders
- Add option to apply validation on form setup. The default behavior is that the form is validated
  on the setup, so it doesn't break on previous versions. This does not apply to vanilla 
  implementations